### PR TITLE
fix: Enable Corepack in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
         uses: actions/setup-node@v3.7.0
         with:
           node-version: ">=18.0.0"
-          cache: 'yarn'
       - name: Test
         run: yarn install && yarn test
 
@@ -28,6 +27,5 @@ jobs:
         uses: actions/setup-node@v3.7.0
         with:
           node-version: ">=18.0.0"
-          cache: 'yarn'
       - name: Test
         run: yarn install && yarn prettier --check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,20 +7,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Enable Corepack
+        run: corepack enable
       - name: Setup Node.js environment
         uses: actions/setup-node@v3.7.0
         with:
           node-version: ">=18.0.0"
+          cache: 'yarn'
       - name: Test
         run: yarn install && yarn test
+
   format:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Enable Corepack
+        run: corepack enable
       - name: Setup Node.js environment
         uses: actions/setup-node@v3.7.0
         with:
           node-version: ">=18.0.0"
+          cache: 'yarn'
       - name: Test
-        run: yarn prettier --check .
+        run: yarn install && yarn prettier --check .


### PR DESCRIPTION
Corepack needs to be enabled before node setup for some arcane reason: https://github.com/actions/setup-node/issues/480